### PR TITLE
Replacing imp for importlib

### DIFF
--- a/mutiny.py
+++ b/mutiny.py
@@ -37,7 +37,7 @@
 
 import datetime
 import errno
-import imp
+import importlib
 import os.path
 import os
 import signal


### PR DESCRIPTION
replaces deprecated module imp with importlib courtesy of santosomar